### PR TITLE
Route disappeared without error display and swap location fix

### DIFF
--- a/app/src/main/java/com/aws/amazonlocation/ui/main/explore/ExploreFragment.kt
+++ b/app/src/main/java/com/aws/amazonlocation/ui/main/explore/ExploreFragment.kt
@@ -1492,6 +1492,7 @@ class ExploreFragment :
                                                 R.color.btn_go_disable
                                             )
                                         )
+                                        showCalculateRouteAPIError(TravelMode.Walking.value)
                                         mViewModel.mWalkingData = null
                                         isCalculateWalkApiError = true
                                         mBinding.bottomSheetDirectionSearch.clWalkLoader.hide()
@@ -1504,6 +1505,7 @@ class ExploreFragment :
                                                 R.color.btn_go_disable
                                             )
                                         )
+                                        showCalculateRouteAPIError(TravelMode.Car.value)
                                         isCalculateDriveApiError = true
                                         mViewModel.mCarData = null
                                         mBinding.bottomSheetDirectionSearch.clDriveLoader.hide()
@@ -1516,6 +1518,7 @@ class ExploreFragment :
                                                 R.color.btn_go_disable
                                             )
                                         )
+                                        showCalculateRouteAPIError(TravelMode.Truck.value)
                                         mViewModel.mTruckData = null
                                         isCalculateTruckApiError = true
                                         mBinding.bottomSheetDirectionSearch.clTruckLoader.hide()
@@ -1528,6 +1531,7 @@ class ExploreFragment :
                                                 R.color.btn_go_disable
                                             )
                                         )
+                                        showCalculateRouteAPIError(TRAVEL_MODE_BICYCLE)
                                         mViewModel.mBicycleData = null
                                         isCalculateBicycleApiError = true
                                         mBinding.bottomSheetDirectionSearch.clBicycleLoader.hide()
@@ -1540,6 +1544,7 @@ class ExploreFragment :
                                                 R.color.btn_go_disable
                                             )
                                         )
+                                        showCalculateRouteAPIError(TRAVEL_MODE_MOTORCYCLE)
                                         mViewModel.mMotorcycleData = null
                                         isCalculateMotorcycleApiError = true
                                         mBinding.bottomSheetDirectionSearch.clMotorcycleLoader.hide()
@@ -1825,6 +1830,12 @@ class ExploreFragment :
                     showError(it.messageResource.toString())
                 }
             }
+        }
+    }
+
+    private fun showCalculateRouteAPIError(value: String) {
+        if (mTravelMode == value) {
+            showError(getString(R.string.no_route_found))
         }
     }
 
@@ -2317,27 +2328,22 @@ class ExploreFragment :
             }
 
             bottomSheetDirectionSearch.apply {
-                if (checkInternetConnection()) {
-                    clDrive.setOnClickListener {
-                        mTravelMode = TravelMode.Car.value
-                        mViewModel.mCarData?.let {
-                            tvDriveSelected.show()
-                            showViews(cardRoutingOption)
-                            hideViews(tvTruckSelected, tvWalkSelected, tvBicycleSelected, tvMotorcycleSelected)
-                            adjustMapBound()
-                            drawPolyLineOnMapCardClick(
-                                it.legs,
-                                isLineUpdate = false,
-                                isWalk = false,
-                                isLocationIcon = false
-                            )
+                clDrive.setOnClickListener {
+                    if (checkInternetConnection()) {
+                        if (mViewModel.mCarData == null) {
+                            showError(getString(R.string.no_route_found))
+                            return@setOnClickListener
                         }
-                        recordTravelModeChange()
+                        setCarClickData()
                     }
                 }
 
                 clWalk.setOnClickListener {
                     if (checkInternetConnection()) {
+                        if (mViewModel.mWalkingData == null) {
+                            showError(getString(R.string.no_route_found))
+                            return@setOnClickListener
+                        }
                         mTravelMode = TravelMode.Walking.value
                         mViewModel.mWalkingData?.let {
                             tvWalkSelected.show()
@@ -2361,6 +2367,10 @@ class ExploreFragment :
 
                 clTruck.setOnClickListener {
                     if (checkInternetConnection()) {
+                        if (mViewModel.mTruckData == null) {
+                            showError(getString(R.string.no_route_found))
+                            return@setOnClickListener
+                        }
                         mTravelMode = TravelMode.Truck.value
                         mViewModel.mTruckData?.let {
                             tvTruckSelected.show()
@@ -2380,6 +2390,10 @@ class ExploreFragment :
 
                 clBicycle.setOnClickListener {
                     if (checkInternetConnection()) {
+                        if (mViewModel.mBicycleData == null) {
+                            showError(getString(R.string.no_route_found))
+                            return@setOnClickListener
+                        }
                         mTravelMode = TRAVEL_MODE_BICYCLE
                         mViewModel.mBicycleData?.let {
                             tvBicycleSelected.show()
@@ -2403,6 +2417,10 @@ class ExploreFragment :
 
                 clMotorcycle.setOnClickListener {
                     if (checkInternetConnection()) {
+                        if (mViewModel.mMotorcycleData == null) {
+                            showError(getString(R.string.no_route_found))
+                            return@setOnClickListener
+                        }
                         mTravelMode = TRAVEL_MODE_MOTORCYCLE
                         mViewModel.mMotorcycleData?.let {
                             tvMotorcycleSelected.show()
@@ -3158,6 +3176,23 @@ class ExploreFragment :
         }
     }
 
+    private fun BottomSheetDirectionSearchBinding.setCarClickData() {
+        mTravelMode = TravelMode.Car.value
+        mViewModel.mCarData?.let {
+            tvDriveSelected.show()
+            showViews(cardRoutingOption)
+            hideViews(tvTruckSelected, tvWalkSelected, tvBicycleSelected, tvMotorcycleSelected)
+            adjustMapBound()
+            drawPolyLineOnMapCardClick(
+                it.legs,
+                isLineUpdate = false,
+                isWalk = false,
+                isLocationIcon = false
+            )
+        }
+        recordTravelModeChange()
+    }
+
     private fun recordTravelModeChange() {
         if (mBottomSheetHelper.isDirectionSearchSheetVisible()) {
             val isMetric = isMetric(mPreferenceManager.getValue(KEY_UNIT_SYSTEM, ""))
@@ -3736,6 +3771,8 @@ class ExploreFragment :
                         )
                         clTruck.invisible()
                         clWalk.invisible()
+                        clBicycle.hide()
+                        clMotorcycle.hide()
                     }
                     layoutCardError.groupCardErrorNoSearchFound.hide()
                     layoutCardError.root.hide()
@@ -4069,7 +4106,9 @@ class ExploreFragment :
         mMapHelper.addLiveLocationMarker(false)
         mBinding.tvDistance.text = ""
         mBinding.tvNavigationName.text = ""
-        mBinding.bottomSheetDirectionSearch.clDrive.performClick()
+        mBinding.bottomSheetDirectionSearch.apply {
+            setCarClickData()
+        }
         mRouteFinish = true
         mNavigationList.clear()
         mMapHelper.removeLocationListener()
@@ -4330,8 +4369,6 @@ class ExploreFragment :
 
     private fun BottomSheetDirectionSearchBinding.routeOptionClose() {
         mIsRouteOptionsOpened = false
-        mIsAvoidTolls = mPreferenceManager.getValue(KEY_AVOID_TOLLS, false)
-        mIsAvoidFerries = mPreferenceManager.getValue(KEY_AVOID_FERRIES, false)
         ivDown.show()
         cardRoutingOption.setCardBackgroundColor(
             ContextCompat.getColor(
@@ -4878,7 +4915,10 @@ class ExploreFragment :
 
     private fun BottomSheetDirectionSearchBinding.cardRouteOptionShow() {
         hideViews(rvSearchPlacesDirection, rvSearchPlacesSuggestionDirection, clMyLocation.root)
-        showViews(cardRoutingOption, cardMapOption)
+        if (mTravelMode == TravelMode.Car.value || mTravelMode == TravelMode.Truck.value) {
+            cardRoutingOption.show()
+        }
+        showViews(cardMapOption)
     }
 
     private fun BottomSheetDirectionSearchBinding.cardRouteOptionHide() {


### PR DESCRIPTION
- On the selected vehicle, if API fails, the user can see the error message [ALS-1660](https://makeen.atlassian.net/browse/ALS-1660)
- On swap location route options appear for walk, bicycle, and motorcycle fix
- On route option card close avoid tolls and ferries get reset fix

[ALS-1660]: https://makeen.atlassian.net/browse/ALS-1660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ